### PR TITLE
fix: metro module resolution priority

### DIFF
--- a/crates/craby_cli/src/commands/init/react_native.rs
+++ b/crates/craby_cli/src/commands/init/react_native.rs
@@ -90,22 +90,12 @@ pub fn setup_react_native_project_impl(dest_dir: &Path, pkg_name: &str) -> anyho
         "#
     };
 
-    let entry_file = formatdoc! {
-        r#"
-        import {{ AppRegistry }} from 'react-native';
-        import App from './App';
-
-        AppRegistry.registerComponent('{app_name}', () => App);
-        "#
-    };
-
     debug!("Overwriting files");
     fs::write(project_dir.join("metro.config.js"), metro_config)?;
     fs::write(
         project_dir.join("react-native.config.js"),
         react_native_config,
     )?;
-    fs::write(project_dir.join("index.js"), entry_file)?;
 
     let dest_dir = dest_dir.join("example");
     debug!(

--- a/packages/craby-devkit/src/metro/config.ts
+++ b/packages/craby-devkit/src/metro/config.ts
@@ -10,6 +10,7 @@ export function getMetroConfig(rootDir: string, options: GetMetroConfigOptions) 
     projectRoot: rootDir,
     watchFolders: [getWorkspaceRoot(rootDir)],
     resolver: {
+      sourceExts: ['ts', 'tsx', 'js', 'jsx', 'json'],
       resolveRequest: createResolver({ rootPath: rootDir, ...options?.resolverOptions }),
     },
   };

--- a/packages/craby-devkit/src/metro/resolver.ts
+++ b/packages/craby-devkit/src/metro/resolver.ts
@@ -55,8 +55,6 @@ export function createResolver(options: CreateResolverOptions): CustomResolver {
       extensions: finalExtensions,
       conditionNames: ['react-native', 'require', 'node', 'default'],
       mainFields: ['react-native', 'browser', 'main'],
-      mainFiles: ['index'],
-      modules: ['node_modules', path.join(rootPath, 'src')],
     });
 
     function resolveSync(resolveDir: string, request: string) {


### PR DESCRIPTION
# Description

Metro's [default resolver prioritizes](https://metrobundler.dev/docs/configuration/#sourceexts) 'json' over 'tsx', causing './App' 
imports to incorrectly resolve to App.json instead of App.tsx.

Adjusted priority order to: `['ts', 'tsx', 'js', 'jsx', 'json']`