### PR TITLE
docs: fix typo

### DIFF
--- a/docs/guide/build.md
+++ b/docs/guide/build.md
@@ -27,7 +27,7 @@ npx craby build
 
 By default, this builds for:
 
-**Android**
+**iOS**
 
 | Identifier | Target | Description |
 |-------------|--------|-------------|
@@ -40,7 +40,7 @@ By default, this builds for:
 The simulator target libraries (`ios-arm64-simulator` and `ios-x86_64-simulator`) are merged into a single universal binary (`ios-arm64_x86_64-simulator`) using `lipo` command line tool.
 :::
 
-**iOS**
+**Android**
 
 | ABI | Target | Description |
 |-------------|--------|-------------|


### PR DESCRIPTION
## Description
Fixed a typo in the build guide documentation where the "Android" and "iOS" section headers were swapped.

## Changes
- Fixed swapped section headers in `docs/guide/build.md`
  - Changed "**Android**" to "**iOS**" for the iOS build targets section
  - Changed "**iOS**" to "**Android**" for the Android build targets section

## Type of Change
- [x] Documentation update
