### PR TITLE
fix: use published package version

### DIFF
--- a/crates/craby_cli/src/commands/init/handler.rs
+++ b/crates/craby_cli/src/commands/init/handler.rs
@@ -24,7 +24,7 @@ pub fn perform(opts: InitOptions) -> anyhow::Result<()> {
 
     let template_data = prompt_for_template_data(&opts.pkg_name)?;
     setup_template(&dest_dir, &template_data)?;
-    setup_react_native_project(&dest_dir, &opts.pkg_name)?;
+    setup_react_native_project(&dest_dir, &opts.pkg_name, &template_data)?;
     setup_rust_toolchain()?;
 
     let outro = formatdoc! {

--- a/crates/craby_cli/src/commands/init/react_native.rs
+++ b/crates/craby_cli/src/commands/init/react_native.rs
@@ -6,12 +6,17 @@ use log::debug;
 
 use crate::utils::{
     log::success,
+    template::TemplateData,
     terminal::{run_command, with_spinner},
 };
 
-pub fn setup_react_native_project(dest_dir: &Path, pkg_name: &str) -> anyhow::Result<()> {
+pub fn setup_react_native_project(
+    dest_dir: &Path,
+    pkg_name: &str,
+    template_data: &TemplateData,
+) -> anyhow::Result<()> {
     with_spinner("Setting up React Native project...", |_| {
-        if let Err(e) = setup_react_native_project_impl(dest_dir, pkg_name) {
+        if let Err(e) = setup_react_native_project_impl(dest_dir, pkg_name, template_data) {
             anyhow::bail!("Failed to setup React Native project: {}", e);
         }
         Ok(())
@@ -20,7 +25,11 @@ pub fn setup_react_native_project(dest_dir: &Path, pkg_name: &str) -> anyhow::Re
     Ok(())
 }
 
-pub fn setup_react_native_project_impl(dest_dir: &Path, pkg_name: &str) -> anyhow::Result<()> {
+pub fn setup_react_native_project_impl(
+    dest_dir: &Path,
+    pkg_name: &str,
+    template_data: &TemplateData,
+) -> anyhow::Result<()> {
     let app_name = format!("{}Example", pascal_case(pkg_name));
 
     run_command(
@@ -51,7 +60,10 @@ pub fn setup_react_native_project_impl(dest_dir: &Path, pkg_name: &str) -> anyho
         if let Some(dev_dependencies) = obj.get_mut("devDependencies") {
             if let Some(dev_dependencies_obj) = dev_dependencies.as_object_mut() {
                 debug!("Inserting devDependencies");
-                dev_dependencies_obj.insert("@craby/devkit".to_string(), serde_json::json!("*"));
+                dev_dependencies_obj.insert(
+                    "@craby/devkit".to_string(),
+                    serde_json::json!(template_data["pkg_version"].clone()),
+                );
             }
         }
 

--- a/crates/craby_cli/src/commands/init/template.rs
+++ b/crates/craby_cli/src/commands/init/template.rs
@@ -89,6 +89,7 @@ pub fn prompt_for_template_data(pkg_name: &str) -> anyhow::Result<TemplateData> 
         ("cxx_name", cxx_name.to_string()),
         ("objc_provider", objc_provider.to_string()),
         ("year", current_year.to_string()),
+        ("pkg_version", format!("^{}", env!("CARGO_PKG_VERSION"))),
     ]);
 
     Ok(template_data)

--- a/template/package.json
+++ b/template/package.json
@@ -60,13 +60,13 @@
   },
   "homepage": "{{ repository_url }}#readme",
   "dependencies": {
-    "craby-modules": "*"
+    "craby-modules": "{{ pkg_version }}"
   },
   "devDependencies": {
     "@biomejs/biome": "2.2.7",
     "@react-native-community/cli-types": "^20.0.2",
     "@types/react": "^19.0.0",
-    "crabygen": "*",
+    "crabygen": "{{ pkg_version }}",
     "react": "19.1.1",
     "react-native": "0.82.1",
     "tsdown": "^0.15.10",


### PR DESCRIPTION
# Description

Package version was set to "*", which caused npm to install the stable 
version (0.0.0) instead of the intended published version (e.g., 0.1.0-rc.0).

<img width="289" height="67" alt="Screenshot 2025-11-06 at 23 17 01" src="https://github.com/user-attachments/assets/e2351082-0cee-4fcf-9b16-fd3124994eb2" />

closes #44 