### PR TITLE
feat: add build target option

### DIFF
--- a/crates/craby_build/src/constants.rs
+++ b/crates/craby_build/src/constants.rs
@@ -7,6 +7,7 @@ pub mod toolchain {
 
     use super::{android::Abi, ios::Identifier};
 
+    #[derive(Debug, Clone, Copy)]
     pub enum Target {
         Android(Abi),
         Ios(Identifier),
@@ -31,17 +32,37 @@ pub mod toolchain {
         }
     }
 
+    impl TryFrom<&str> for Target {
+        type Error = anyhow::Error;
+
+        fn try_from(value: &str) -> Result<Self, Self::Error> {
+            match value {
+                "aarch64-linux-android" => Ok(Target::Android(Abi::Arm64V8a)),
+                "armv7-linux-androideabi" => Ok(Target::Android(Abi::ArmeAbiV7a)),
+                "x86_64-linux-android" => Ok(Target::Android(Abi::X86_64)),
+                "i686-linux-android" => Ok(Target::Android(Abi::X86)),
+                "aarch64-apple-ios" => Ok(Target::Ios(Identifier::Arm64)),
+                "aarch64-apple-ios-sim" => Ok(Target::Ios(Identifier::Arm64Simulator)),
+                "x86_64-apple-ios" => Ok(Target::Ios(Identifier::X86_64Simulator)),
+                _ => anyhow::bail!("Invalid target: {}", value),
+            }
+        }
+    }
+
     impl Display for Target {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             write!(f, "{}", self.to_str())
         }
     }
 
-    pub const BUILD_TARGETS: [Target; 7] = [
+    pub const DEFAULT_ANDROID_TARGETS: [Target; 4] = [
         Target::Android(Abi::Arm64V8a),
         Target::Android(Abi::ArmeAbiV7a),
         Target::Android(Abi::X86_64),
         Target::Android(Abi::X86),
+    ];
+
+    pub const DEFAULT_IOS_TARGETS: [Target; 3] = [
         Target::Ios(Identifier::Arm64),
         Target::Ios(Identifier::Arm64Simulator),
         Target::Ios(Identifier::X86_64Simulator),
@@ -58,6 +79,7 @@ pub mod android {
     /// See https://github.com/facebook/react-native/blob/v0.76.0/packages/react-native/gradle/libs.versions.toml
     pub const MIN_SDK_VERSION: u8 = 23;
 
+    #[derive(Debug, Clone, Copy)]
     pub enum Abi {
         Arm64V8a,
         ArmeAbiV7a,
@@ -122,6 +144,7 @@ pub mod android {
 }
 
 pub mod ios {
+    #[derive(Debug, Clone, Copy)]
     pub enum Identifier {
         /// For device
         Arm64,

--- a/crates/craby_build/src/platform/android.rs
+++ b/crates/craby_build/src/platform/android.rs
@@ -6,28 +6,21 @@ use owo_colors::OwoColorize;
 
 use crate::{
     cargo::artifact::{ArtifactType, Artifacts},
-    constants::{android::Abi, toolchain::Target},
+    constants::toolchain::Target,
     platform::{
         android::path::ndk_llvm_strip_path,
         common::{replace_cxx_header, replace_cxx_iter_template},
     },
 };
 
-pub const ANDROID_TARGETS: [Target; 4] = [
-    Target::Android(Abi::Arm64V8a),
-    Target::Android(Abi::ArmeAbiV7a),
-    Target::Android(Abi::X86_64),
-    Target::Android(Abi::X86),
-];
-
-pub fn crate_libs(config: &CompleteConfig) -> Result<(), anyhow::Error> {
+pub fn crate_libs(config: &CompleteConfig, build_targets: &[Target]) -> Result<(), anyhow::Error> {
     let jni_base_path = jni_base_path(&config.project_root);
 
-    for target in ANDROID_TARGETS {
+    for target in build_targets {
         debug!("Copying artifacts to JNI base path: {:?}", jni_base_path);
 
-        if let Target::Android(abi) = &target {
-            let artifacts = Artifacts::get_artifacts(config, &target)?;
+        if let Target::Android(abi) = target {
+            let artifacts = Artifacts::get_artifacts(config, target)?;
             let abi = abi.to_str();
 
             artifacts.path_of(ArtifactType::Lib).iter().try_for_each(
@@ -49,8 +42,6 @@ pub fn crate_libs(config: &CompleteConfig) -> Result<(), anyhow::Error> {
 
             // android/src/main/jni/libs/{abi}
             artifacts.copy_to(ArtifactType::Lib, &jni_base_path.join("libs").join(abi))?;
-        } else {
-            unreachable!();
         }
     }
 

--- a/crates/craby_cli/src/commands/doctor/handler.rs
+++ b/crates/craby_cli/src/commands/doctor/handler.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use craby_build::{constants::toolchain::Target, platform::android::ANDROID_TARGETS};
+use craby_build::constants::toolchain::{Target, DEFAULT_ANDROID_TARGETS};
 use craby_common::{
     constants::toolchain::TARGETS,
     env::get_installed_targets,
@@ -64,7 +64,10 @@ pub fn perform(opts: DoctorOptions) -> anyhow::Result<()> {
             Err(e) => {
                 passed &= false;
                 suggestions.push(Suggestion::plain_text(
-                    &format!("Check {} path is set correctly", "$ANDROID_NDK_HOME".yellow()),
+                    &format!(
+                        "Check {} path is set correctly",
+                        "$ANDROID_NDK_HOME".yellow()
+                    ),
                     Some(&formatdoc! {
                         r#"
                         If Android NDK is not installed, please install it from the following link:
@@ -77,7 +80,7 @@ pub fn perform(opts: DoctorOptions) -> anyhow::Result<()> {
         },
     );
 
-    for target in ANDROID_TARGETS {
+    for target in DEFAULT_ANDROID_TARGETS {
         match target {
             Target::Android(abi) => {
                 assert_with_status(

--- a/crates/craby_cli/src/commands/init/rust.rs
+++ b/crates/craby_cli/src/commands/init/rust.rs
@@ -1,6 +1,6 @@
 use std::process::Command;
 
-use craby_build::constants::toolchain::BUILD_TARGETS;
+use craby_build::constants::toolchain::{DEFAULT_ANDROID_TARGETS, DEFAULT_IOS_TARGETS};
 use craby_common::env::is_rustup_installed;
 use owo_colors::OwoColorize;
 
@@ -26,7 +26,12 @@ pub fn setup_rust_toolchain() -> anyhow::Result<()> {
 }
 
 fn setup_rust_targets() -> anyhow::Result<()> {
-    for target in BUILD_TARGETS {
+    for target in [
+        DEFAULT_ANDROID_TARGETS.as_ref(),
+        DEFAULT_IOS_TARGETS.as_ref(),
+    ]
+    .concat()
+    {
         let target = target.to_str();
         let res = Command::new("rustup")
             .args(["target", "add", target])

--- a/crates/craby_cli/src/utils/build_targets.rs
+++ b/crates/craby_cli/src/utils/build_targets.rs
@@ -1,0 +1,36 @@
+use craby_build::constants::toolchain::{Target, DEFAULT_ANDROID_TARGETS, DEFAULT_IOS_TARGETS};
+use craby_common::config::CompleteConfig;
+use owo_colors::OwoColorize;
+
+pub fn get_build_targets(config: &CompleteConfig) -> Result<Vec<Target>, anyhow::Error> {
+    let android =
+        get_targets_with_defaults(config.android.targets.as_ref(), &DEFAULT_ANDROID_TARGETS)?;
+    let ios = get_targets_with_defaults(config.ios.targets.as_ref(), &DEFAULT_IOS_TARGETS)?;
+
+    Ok([android, ios].concat())
+}
+
+pub fn print_build_targets(targets: &[Target]) {
+    for (idx, target) in targets.iter().enumerate() {
+        let is_last = idx == targets.len() - 1;
+        let branch = if is_last { "└─" } else { "├─" };
+        let platform = match target {
+            Target::Android(_) => format!("{}", "(Android)".green()),
+            Target::Ios(_) => format!("{}", "(iOS)".blue()),
+        };
+        println!("{} {} {}", branch, platform, target.to_str().dimmed());
+    }
+}
+
+fn get_targets_with_defaults(
+    config_targets: Option<&Vec<String>>,
+    defaults: &[Target],
+) -> Result<Vec<Target>, anyhow::Error> {
+    match config_targets {
+        Some(targets) => targets
+            .iter()
+            .map(|s| Target::try_from(s.as_str()))
+            .collect(),
+        None => Ok(defaults.to_vec()),
+    }
+}

--- a/crates/craby_cli/src/utils/mod.rs
+++ b/crates/craby_cli/src/utils/mod.rs
@@ -1,3 +1,4 @@
+pub mod build_targets;
 pub mod file;
 pub mod git;
 pub mod log;

--- a/crates/craby_common/src/config/load_config.rs
+++ b/crates/craby_common/src/config/load_config.rs
@@ -29,6 +29,7 @@ pub fn load_config(project_root: &Path) -> Result<CompleteConfig, anyhow::Error>
         project_root: project_root.to_path_buf(),
         project: config.project,
         android: config.android,
+        ios: config.ios,
         source_dir,
     })
 }

--- a/crates/craby_common/src/config/types.rs
+++ b/crates/craby_common/src/config/types.rs
@@ -22,6 +22,7 @@ pub struct LibConfig {
 pub struct Config {
     pub project: ProjectConfig,
     pub android: AndroidConfig,
+    pub ios: IosConfig,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -33,12 +34,19 @@ pub struct ProjectConfig {
 #[derive(Debug, Deserialize, Serialize)]
 pub struct AndroidConfig {
     pub package_name: String,
+    pub targets: Option<Vec<String>>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct IosConfig {
+    pub targets: Option<Vec<String>>,
 }
 
 #[derive(Debug)]
 pub struct CompleteConfig {
     pub project: ProjectConfig,
-    pub android: AndroidConfig,
     pub project_root: PathBuf,
     pub source_dir: PathBuf,
+    pub android: AndroidConfig,
+    pub ios: IosConfig,
 }

--- a/examples/craby-test/craby.toml
+++ b/examples/craby-test/craby.toml
@@ -4,3 +4,5 @@ source_dir = "src"
 
 [android]
 package_name = "rs.craby.crabytest"
+
+[ios]

--- a/template/craby.toml
+++ b/template/craby.toml
@@ -4,3 +4,5 @@ source_dir = "src"
 
 [android]
 package_name = "rs.craby.{{ flat_name }}"
+
+[ios]

--- a/xtask/src/tasks/prepare.rs
+++ b/xtask/src/tasks/prepare.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use craby_build::constants::toolchain::BUILD_TARGETS;
+use craby_build::constants::toolchain::{DEFAULT_ANDROID_TARGETS, DEFAULT_IOS_TARGETS};
 
 use crate::utils::run_command;
 
@@ -18,7 +18,12 @@ pub fn run(opt: Option<&str>) -> Result<()> {
         println!("Setting up toolchain targets...");
         run_command("cargo", &["--version"], None)?;
 
-        for target in BUILD_TARGETS {
+        for target in [
+            DEFAULT_ANDROID_TARGETS.as_ref(),
+            DEFAULT_IOS_TARGETS.as_ref(),
+        ]
+        .concat()
+        {
             println!("Installing target: {}", target.to_str());
             run_command("rustup", &["target", "install", target.to_str()], None)?;
         }


### PR DESCRIPTION
# Description

**BREAKING CHANGE**: The `[ios]` section is now mandatory in `craby.toml` configuration files.

```diff
[project]
name = "craby_test"
source_dir = "src"

[android]
package_name = "rs.craby.crabytest"

+ [ios]
```

Add `android.targets`, `ios.targets` options to configure build targets.

```rs
// Default targets:
pub const DEFAULT_ANDROID_TARGETS: [Target; 4] = [
    Target::Android(Abi::Arm64V8a),
    Target::Android(Abi::ArmeAbiV7a),
    Target::Android(Abi::X86_64),
    Target::Android(Abi::X86),
];

pub const DEFAULT_IOS_TARGETS: [Target; 3] = [
    Target::Ios(Identifier::Arm64),
    Target::Ios(Identifier::Arm64Simulator),
    Target::Ios(Identifier::X86_64Simulator),
];
```

closes #68