### PR TITLE
fix(codegen): warn on missing or stale mod declarations in lib.rs

### DIFF
--- a/crates/craby_cli/src/commands/codegen/handler.rs
+++ b/crates/craby_cli/src/commands/codegen/handler.rs
@@ -144,13 +144,11 @@ pub fn perform(opts: CodegenOptions) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Checks `lib.rs` for missing or stale `mod <impl>` declarations.
+/// Checks `lib.rs` for missing `mod <impl>` declarations.
 ///
-/// Since `lib.rs` is never overwritten (to preserve user code), module additions
-/// or removals won't be reflected automatically. This function warns when:
-///
-/// - An expected `mod <name>_impl;` is absent from the file (module added to spec)
-/// - A `mod <name>_impl;` exists in the file but is no longer in the schema (module removed)
+/// Since `lib.rs` is never overwritten (to preserve user code), adding a new
+/// craby module won't be reflected automatically. This function warns when an
+/// expected `mod <name>_impl;` is absent from the file.
 fn check_lib_rs_mods(ctx: &CodegenContext) {
     let lib_rs_path = crate_dir(&ctx.root).join("src").join("lib.rs");
 
@@ -159,44 +157,12 @@ fn check_lib_rs_mods(ctx: &CodegenContext) {
         Err(_) => return,
     };
 
-    let expected: Vec<String> = ctx
-        .schemas
-        .iter()
-        .map(|s| impl_mod_name(&s.module_name))
-        .collect();
-
-    // Warn about missing declarations
-    for mod_name in &expected {
+    for mod_name in ctx.schemas.iter().map(|s| impl_mod_name(&s.module_name)) {
         if !content.contains(&format!("mod {mod_name}")) {
             warn!(
                 "lib.rs is missing module declaration: `pub(crate) mod {mod_name};`\n  → Add it manually or delete lib.rs to regenerate."
             );
         }
-    }
-
-    // Warn about stale declarations (ends with `_impl` but no longer in schema)
-    for line in content.lines() {
-        if let Some(mod_name) = parse_mod_name(line.trim()) {
-            if mod_name.ends_with("_impl") && !expected.iter().any(|m| m == mod_name) {
-                warn!(
-                    "lib.rs contains a stale module declaration: `mod {mod_name};`\n  → Remove it manually."
-                );
-            }
-        }
-    }
-}
-
-/// Extracts the module name from a `mod` declaration line.
-///
-/// Matches: `mod foo;`, `pub mod foo;`, `pub(crate) mod foo;`
-fn parse_mod_name(line: &str) -> Option<&str> {
-    let line = line.strip_suffix(';')?.trim();
-    let idx = line.rfind("mod ")? + 4;
-    let name = line[idx..].trim();
-    if !name.is_empty() && name.chars().all(|c| c.is_alphanumeric() || c == '_') {
-        Some(name)
-    } else {
-        None
     }
 }
 

--- a/crates/craby_cli/src/commands/codegen/handler.rs
+++ b/crates/craby_cli/src/commands/codegen/handler.rs
@@ -15,8 +15,8 @@ use craby_codegen::{
     },
     types::CodegenContext,
 };
-use craby_common::{config::load_config, constants::craby_tmp_dir, env::is_initialized};
-use log::{debug, info};
+use craby_common::{config::load_config, constants::{crate_dir, craby_tmp_dir, impl_mod_name}, env::is_initialized};
+use log::{debug, info, warn};
 use owo_colors::OwoColorize;
 
 use crate::utils::{file::write_file, schema::print_schema};
@@ -134,12 +134,70 @@ pub fn perform(opts: CodegenOptions) -> anyhow::Result<()> {
         }
     }
 
+    check_lib_rs_mods(&ctx);
+
     info!(
         "Codegen completed successfully 🎉 {}",
         format!("({}ms)", elapsed).dimmed()
     );
 
     Ok(())
+}
+
+/// Checks `lib.rs` for missing or stale `mod <impl>` declarations.
+///
+/// Since `lib.rs` is never overwritten (to preserve user code), module additions
+/// or removals won't be reflected automatically. This function warns when:
+///
+/// - An expected `mod <name>_impl;` is absent from the file (module added to spec)
+/// - A `mod <name>_impl;` exists in the file but is no longer in the schema (module removed)
+fn check_lib_rs_mods(ctx: &CodegenContext) {
+    let lib_rs_path = crate_dir(&ctx.root).join("src").join("lib.rs");
+
+    let content = match std::fs::read_to_string(&lib_rs_path) {
+        Ok(c) => c,
+        Err(_) => return,
+    };
+
+    let expected: Vec<String> = ctx
+        .schemas
+        .iter()
+        .map(|s| impl_mod_name(&s.module_name))
+        .collect();
+
+    // Warn about missing declarations
+    for mod_name in &expected {
+        if !content.contains(&format!("mod {mod_name}")) {
+            warn!(
+                "lib.rs is missing module declaration: `pub(crate) mod {mod_name};`\n  → Add it manually or delete lib.rs to regenerate."
+            );
+        }
+    }
+
+    // Warn about stale declarations (ends with `_impl` but no longer in schema)
+    for line in content.lines() {
+        if let Some(mod_name) = parse_mod_name(line.trim()) {
+            if mod_name.ends_with("_impl") && !expected.iter().any(|m| m == mod_name) {
+                warn!(
+                    "lib.rs contains a stale module declaration: `mod {mod_name};`\n  → Remove it manually."
+                );
+            }
+        }
+    }
+}
+
+/// Extracts the module name from a `mod` declaration line.
+///
+/// Matches: `mod foo;`, `pub mod foo;`, `pub(crate) mod foo;`
+fn parse_mod_name(line: &str) -> Option<&str> {
+    let line = line.strip_suffix(';')?.trim();
+    let idx = line.rfind("mod ")? + 4;
+    let name = line[idx..].trim();
+    if !name.is_empty() && name.chars().all(|c| c.is_alphanumeric() || c == '_') {
+        Some(name)
+    } else {
+        None
+    }
 }
 
 fn with_generated_comment(path: &Path, code: &str) -> String {

--- a/examples/craby-test/cpp/CxxCrabyTestModule.cpp
+++ b/examples/craby-test/cpp/CxxCrabyTestModule.cpp
@@ -453,11 +453,11 @@ jsi::Value CxxCrabyTestModule::promiseStringMethod(jsi::Runtime &rt,
     }
 
     auto arg0$raw = args[0].asString(rt).utf8(rt);
-    auto arg0 = rust::Str(arg0$raw.data(), arg0$raw.size());
     react::AsyncPromise<double> promise(rt, callInvoker);
 
-    thisModule.threadPool_->enqueue([it_, promise, arg0]() mutable {
+    thisModule.threadPool_->enqueue([it_, promise, arg0$raw]() mutable {
       try {
+        auto arg0 = rust::Str(arg0$raw.data(), arg0$raw.size());
         auto ret = craby::crabytest::bridging::promiseStringMethod(*it_, arg0);
         promise.resolve(ret);
       } catch (const jsi::JSError &err) {


### PR DESCRIPTION
Fixes #80.

## Summary

- `lib.rs` is never overwritten (to preserve user-written code), so adding a craby module was silently ignored
- After codegen, the existing `lib.rs` is now scanned for missing `mod <name>_impl;` declarations
- If an expected module is absent, a `WARN` log is emitted so users know to update the file manually

## Example output

When a new module is added to the spec but `lib.rs` hasn't been updated:

```
WARN lib.rs is missing module declaration: `pub(crate) mod new_module_impl;`
  → Add it manually or delete lib.rs to regenerate.
```

## Test plan

- [x] Tested locally: missing mod warning fires correctly
- [x] `cargo clippy` passes with `--deny warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)