### PR TITLE
Choose Android NDK path with fallback

### DIFF
--- a/crates/craby_build/src/platform/android.rs
+++ b/crates/craby_build/src/platform/android.rs
@@ -118,7 +118,7 @@ pub mod path {
         Ok(ndk_bin_path()?.join("llvm-strip"))
     }
 
-    fn ndk_root_path() -> Result<PathBuf, anyhow::Error> {
+    pub fn ndk_root_path() -> Result<PathBuf, anyhow::Error> {
         if let Ok(path) = std::env::var("ANDROID_NDK_HOME") {
             return Ok(PathBuf::from(path));
         }

--- a/crates/craby_build/src/platform/android.rs
+++ b/crates/craby_build/src/platform/android.rs
@@ -78,7 +78,10 @@ fn strip_lib(lib: &PathBuf) -> Result<(), anyhow::Error> {
 }
 
 pub mod path {
-    use std::path::PathBuf;
+    use std::{
+        fs,
+        path::{Path, PathBuf},
+    };
 
     use crate::constants::android::Abi;
 
@@ -90,10 +93,7 @@ pub mod path {
             _ => Err(anyhow::anyhow!("Unsupported OS: {}", std::env::consts::OS)),
         }?;
 
-        let path =
-            PathBuf::from(std::env::var("ANDROID_NDK_HOME").map_err(|_| {
-                anyhow::anyhow!("`ANDROID_NDK_HOME` environment variable is not set")
-            })?)
+        let path = ndk_root_path()?
             .join("toolchains")
             .join("llvm")
             .join("prebuilt")
@@ -116,5 +116,40 @@ pub mod path {
 
     pub fn ndk_llvm_strip_path() -> Result<PathBuf, anyhow::Error> {
         Ok(ndk_bin_path()?.join("llvm-strip"))
+    }
+
+    fn ndk_root_path() -> Result<PathBuf, anyhow::Error> {
+        if let Ok(path) = std::env::var("ANDROID_NDK_HOME") {
+            return Ok(PathBuf::from(path));
+        }
+
+        let ndk_dir = PathBuf::from(std::env::var("ANDROID_HOME").map_err(|_| {
+            anyhow::anyhow!("`ANDROID_NDK_HOME` or `ANDROID_HOME` environment variable is not set")
+        })?)
+        .join("ndk");
+
+        latest_ndk_path(&ndk_dir)
+            .ok_or_else(|| anyhow::anyhow!("Android NDK not found in {}", ndk_dir.display()))
+    }
+
+    fn latest_ndk_path(ndk_dir: &Path) -> Option<PathBuf> {
+        fn ndk_version_key(path: &Path) -> Option<Vec<u64>> {
+            path.file_name()?
+                .to_string_lossy()
+                .split('.')
+                .map(|part| part.parse::<u64>())
+                .collect::<Result<Vec<_>, _>>()
+                .ok()
+        }
+
+        fs::read_dir(ndk_dir)
+            .ok()?
+            .filter_map(|entry| {
+                let path = entry.ok()?.path();
+                path.is_dir().then_some(path)
+            })
+            .filter_map(|path| ndk_version_key(&path).map(|key| (key, path)))
+            .max_by(|(left, _), (right, _)| left.cmp(right))
+            .map(|(_, path)| path)
     }
 }

--- a/crates/craby_cli/src/commands/doctor/handler.rs
+++ b/crates/craby_cli/src/commands/doctor/handler.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use craby_build::constants::toolchain::{Target, DEFAULT_ANDROID_TARGETS};
-use craby_build::platform::android::path::ndk_bin_path;
+use craby_build::platform::android::path::ndk_root_path;
 use craby_common::{
     constants::toolchain::TARGETS,
     env::get_installed_targets,
@@ -58,15 +58,15 @@ pub fn perform(opts: DoctorOptions) -> anyhow::Result<()> {
     });
 
     println!("\n{}", "Android".bold().dimmed());
-    let ndk_bin_path = ndk_bin_path();
-    let ndk_label = match &ndk_bin_path {
+    let ndk_path = ndk_root_path();
+    let ndk_label = match &ndk_path {
         Ok(path) => format!(
             "Android NDK toolchain {}",
             format!("({})", path.display()).dimmed()
         ),
-        Err(_) => "Android NDK toolchain".to_string(),
+        Err(_) => "Android NDK".to_string(),
     };
-    assert_with_status(&ndk_label, || match ndk_bin_path {
+    assert_with_status(&ndk_label, || match ndk_path {
         Ok(path) if path.try_exists()? => Ok(Status::Ok),
         Ok(path) => {
             passed &= false;

--- a/crates/craby_cli/src/commands/doctor/handler.rs
+++ b/crates/craby_cli/src/commands/doctor/handler.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use craby_build::constants::toolchain::{Target, DEFAULT_ANDROID_TARGETS};
+use craby_build::platform::android::path::ndk_bin_path;
 use craby_common::{
     constants::toolchain::TARGETS,
     env::get_installed_targets,
@@ -57,28 +58,34 @@ pub fn perform(opts: DoctorOptions) -> anyhow::Result<()> {
     });
 
     println!("\n{}", "Android".bold().dimmed());
-    assert_with_status(
-        &format!("Environment variable: {}", "ANDROID_NDK_HOME".dimmed()),
-        || match std::env::var("ANDROID_NDK_HOME") {
-            Ok(_) => Ok(Status::Ok),
-            Err(e) => {
-                passed &= false;
-                suggestions.push(Suggestion::plain_text(
-                    &format!(
-                        "Check {} path is set correctly",
-                        "$ANDROID_NDK_HOME".yellow()
-                    ),
-                    Some(&formatdoc! {
-                        r#"
-                        If Android NDK is not installed, please install it from the following link:
-                        {link}"#,
-                        link = "https://developer.android.com/ndk/downloads".dimmed().underline()
-                    }),
-                ));
-                anyhow::bail!("Environment variable is not set: {}", e);
-            }
-        },
-    );
+    let ndk_bin_path = ndk_bin_path();
+    let ndk_label = match &ndk_bin_path {
+        Ok(path) => format!(
+            "Android NDK toolchain {}",
+            format!("({})", path.display()).dimmed()
+        ),
+        Err(_) => "Android NDK toolchain".to_string(),
+    };
+    assert_with_status(&ndk_label, || match ndk_bin_path {
+        Ok(path) if path.try_exists()? => Ok(Status::Ok),
+        Ok(path) => {
+            passed &= false;
+            anyhow::bail!("Android NDK toolchain not found: {}", path.display());
+        }
+        Err(e) => {
+            passed &= false;
+            suggestions.push(Suggestion::plain_text(
+                "Set Android NDK path",
+                Some(&formatdoc! {
+                    r#"
+                    Set ANDROID_NDK_HOME to a specific NDK path, or set ANDROID_HOME to an Android SDK path that contains ndk/<version>.
+                    {link}"#,
+                    link = "https://developer.android.com/ndk/downloads".dimmed().underline()
+                }),
+            ));
+            Err(e)
+        }
+    });
 
     for target in DEFAULT_ANDROID_TARGETS {
         match target {

--- a/docs/content/docs/get-started/create-project.mdx
+++ b/docs/content/docs/get-started/create-project.mdx
@@ -33,7 +33,7 @@ Before you begin, make sure you have the following installed:
 - **Android NDK**: [Download](https://developer.android.com/ndk/downloads)
 
 ```bash
-# Set a specific NDK path
+# Set `ANDROID_NDK_HOME` environment variable
 export ANDROID_NDK_HOME=/path/to/android-ndk
 
 # Or let Craby find the latest NDK under the Android SDK

--- a/docs/content/docs/get-started/create-project.mdx
+++ b/docs/content/docs/get-started/create-project.mdx
@@ -33,8 +33,11 @@ Before you begin, make sure you have the following installed:
 - **Android NDK**: [Download](https://developer.android.com/ndk/downloads)
 
 ```bash
-# Set `ANDROID_NDK_HOME` environment variable
+# Set a specific NDK path
 export ANDROID_NDK_HOME=/path/to/android-ndk
+
+# Or let Craby find the latest NDK under the Android SDK
+export ANDROID_HOME=/path/to/android-sdk
 ```
 
 ## Create a Project


### PR DESCRIPTION
As I've been learning Rust lately, I decided to contribute to your amazing project that I've had my eye on for a while now.

---

I experienced the first build failure **due to missing `ANDROID_NDK_HOME`**. It was my fault though, I added some enhancements in this procedure for smooth ux.

In that case these changes aren't the right fit for this project, feel free to close this PR. 

## Changed

- Doctor warns only if final `ndk bin path` resolution fails.
- Find fallback Android NDK path from `ANDROID_HOME` env var if  there is no `ANDROID_NDK_HOME` env var.
- Enhance document contents.

## Verification

- `yarn workspace crabygen run execute doctor`

```
✓ Android NDK toolchain (/Users/mj/Library/Android/sdk/ndk/27.1.12297006)
```

- `ANDROID_HOME=asd yarn workspace crabygen run execute doctor`

```
Android
✗ Android NDK - Android NDK not found in asd/ndk
✗ Clang toolchain (arm64-v8a) - Android NDK not found in asd/ndk
✗ Clang toolchain (armeabi-v7a) - Android NDK not found in asd/ndk
✗ Clang toolchain (x86_64) - Android NDK not found in asd/ndk
✗ Clang toolchain (x86) - Android NDK not found in asd/ndk
✗ Build configuration (build.gradle) - No such file or directory (os error 2)

...

╭─ Set Android NDK path
│ Set ANDROID_NDK_HOME to a specific NDK path, or set ANDROID_HOME to an Android SDK path that contains ndk/<version>.
│ https://developer.android.com/ndk/downloads
╰─●
```

- `ANDROID_NDK_HOME=123 ANDROID_HOME=asd yarn workspace crabygen run execute doctor`

```
Android
✗ Android NDK toolchain (123) - Android NDK toolchain not found: 123
✗ Clang toolchain (arm64-v8a) - Clang toolchain not found: arm64-v8a
✗ Clang toolchain (armeabi-v7a) - Clang toolchain not found: armeabi-v7a
✗ Clang toolchain (x86_64) - Clang toolchain not found: x86_64
✗ Clang toolchain (x86) - Clang toolchain not found: x86
✗ Build configuration (build.gradle) - No such file or directory (os error 2)

...
```

On my machine, I set `ANDROID_HOME` in global.
- `unset ANDROID_NDK_HOME && yarn workspace crabygen run execute doctor`

```
✓ Android NDK toolchain (/Users/mj/Library/Android/sdk/ndk/27.1.12297006)
```

